### PR TITLE
Make sure pipx uninstall works

### DIFF
--- a/lib/puppet/provider/package/pipx.rb
+++ b/lib/puppet/provider/package/pipx.rb
@@ -116,4 +116,13 @@ Puppet::Type.type(:package).provide :pipx, :parent => :pip do
     command_options
   end
 
+  def uninstall
+    command = resource_or_provider_command
+    self.class.validate_command(command)
+
+    command_options = ["uninstall", "-q", @resource[:name]]
+
+    execute([command, command_options])
+  end 
+  
 end


### PR DESCRIPTION
As per https://github.com/sbitio/puppet-pipx/issues/4

Tested this on my machine and it works without errors:

```
    package { 'solaar':  # Logitech Ergo Mouse
        provider => 'pipx',
        ensure   => absent,
        require  => Package['pkg-config', 'libcairo2-dev', 'libgirepository1.0-dev', 'libdbus-1-dev'],
    }
```

```
Notice: /Stage[main]/Host2/Package[solaar]/ensure: removed
```